### PR TITLE
Update: 출퇴근 목록 조회 페이지에 들어가지지 않는 문제 해결

### DIFF
--- a/src/main/java/com/goodee/corpdesk/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/goodee/corpdesk/attendance/controller/AttendanceController.java
@@ -39,14 +39,15 @@ public class AttendanceController {
     /**
      * 특정 직원에 대한 출퇴근 목록 화면을 반환합니다.
      *
-     * @param username 직원의 username
      * @return 출퇴근 목록 화면 jsp가 있는 경로
      */
     @GetMapping("list")
-    public String list(@RequestParam("username") String username
+    public String list(@AuthenticationPrincipal UserDetails userDetails
                         , @RequestParam(value = "year", required = false) String year
                         , @RequestParam(value = "month", required = false) String month
                         , Model model) throws Exception {
+        String username = userDetails.getUsername();
+
         String selectedYear = null;
         String selectedMonth = null;
 
@@ -98,7 +99,7 @@ public class AttendanceController {
         String username = userDetails.getUsername();
         ResAttendanceDTO result = attendanceService.checkIn(username);
 
-        return "redirect:/attendance/list?username=" + username;
+        return "redirect:/attendance/list";
 
     }
 
@@ -109,7 +110,7 @@ public class AttendanceController {
         String username = userDetails.getUsername();
         ResAttendanceDTO result = attendanceService.checkOut(attendanceId, username);
 
-        return "redirect:/attendance/list?username=" + username;
+        return "redirect:/attendance/list";
     }
 
 }


### PR DESCRIPTION
#6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 근태 목록이 로그인 사용자 정보를 자동으로 사용하여 표시됩니다. 이제 URL의 username 파라미터 입력이 필요 없습니다.
  * 추가/수정 후 리다이렉트가 /attendance/list로 통일되어 불필요한 쿼리스트링이 제거되었습니다.
  * 이에 따라 보안·프라이버시와 일관성이 개선되고, 북마크/공유가 간편해졌으며 탐색 흐름에서의 오류 가능성이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->