### PR TITLE
Fix: 이메일 변경 시 메세지 출력

### DIFF
--- a/src/main/java/com/goodee/corpdesk/employee/EmployeeController.java
+++ b/src/main/java/com/goodee/corpdesk/employee/EmployeeController.java
@@ -472,7 +472,7 @@ public class EmployeeController {
 
 	@PostMapping("update/email")
 	public String updateEmail(Authentication authentication, @Validated(UpdateEmail.class) Employee employee,
-			BindingResult bindingResult) {
+			BindingResult bindingResult, Model model) {
 		if (bindingResult.hasErrors()) {
 			return "employee/update_email";
 		}
@@ -484,7 +484,8 @@ public class EmployeeController {
 			return "employee/update_email";
 		}
 
-        return "redirect:/employee/link";
+		model.addAttribute("msg", "변경되었습니다.");
+        return "employee/update_email";
     }
 
     @GetMapping("update/password")

--- a/src/main/webapp/WEB-INF/views/employee/update_email.jsp
+++ b/src/main/webapp/WEB-INF/views/employee/update_email.jsp
@@ -45,10 +45,11 @@
 						<div class="app-brand w-100 d-flex justify-content-center border-bottom-0">
 							<h4 class="text-dark text-center mb-5">이메일 변경</h4>
 <%--							<a class="w-auto pl-0" href="/index.html">--%>
-<%--								<img src="images/logo.png" alt="Mono">--%>
-<%--								<span class="brand-name text-dark">MONO</span>--%>
-<%--							</a>--%>
+							<%--								<img src="images/logo.png" alt="Mono">--%>
+							<%--								<span class="brand-name text-dark">MONO</span>--%>
+							<%--							</a>--%>
 						</div>
+						<p>${msg}</p>
 					</div>
 					<div class="card-body px-5 pb-5 pt-0">
 						<form:form action="/employee/update/email" method="post" modelAttribute="employee">


### PR DESCRIPTION
이메일 변경 시 메세지 출력
리다이렉트 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 이메일 변경 완료 시, 별도 이동 없이 현재 화면에서 성공 메시지(“변경되었습니다.”)가 표시됩니다.
  * 입력 오류가 있을 경우 기존과 동일하게 동일 페이지에서 검증 오류가 안내됩니다.
* 스타일
  * 헤더의 브랜드 링크 노출을 정리(비활성화)하여 화면 요소를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->